### PR TITLE
Container for open access MRtrix3 workshop

### DIFF
--- a/recipes/mrtrix3workshop/README.md
+++ b/recipes/mrtrix3workshop/README.md
@@ -1,0 +1,28 @@
+
+----------------------------------
+## mrtrix3workshop/toolVersion ##
+MRtrix3 provides a set of tools to perform various types of diffusion MRI analyses,
+from various forms of tractography through to next-generation group-level analyses.
+It is designed with consistency, performance, and stability in mind,
+and is freely available under an open-source license.
+
+This package installs the MRtrix3 software,
+various other neuroimaging software packages that may be invoked by some MRtrix3 commands,
+and sample data on which the software workshop teaching material is based.
+The sample data can be found at location `/data`.
+
+Example:
+```ShellSession
+mrview
+```
+
+More documentation can be found here: https://mrtrix.readthedocs.io/en/latest/
+
+Citation:
+```text
+J.-D. Tournier, R. E. Smith, D. Raffelt, R. Tabbara, T. Dhollander, M. Pietsch, D. Christiaens, B. Jeurissen, C.-H. Yeh, and A. Connelly.
+MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation.
+NeuroImage, 202 (2019), pp. 116–37.
+```
+
+----------------------------------

--- a/recipes/mrtrix3workshop/build.sh
+++ b/recipes/mrtrix3workshop/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+export toolName='mrtrix3workshop'
+export toolVersion='0.1'
+
+if [ "$1" != "" ]; then
+    echo "Entering Debug mode"
+    export debug=$1
+fi
+
+source ../main_setup.sh
+
+export deployPath=/opt/${toolName}-${toolVersion}
+
+neurodocker generate ${neurodocker_buildMode} \
+   --base-image vnmd/mrtrix3_3.0.4 \
+   --pkg-manager apt \
+   --workdir ${deployPath}/dwifslpreproc/DICOM \
+   --run "curl https://osf.io/2mzbn/download \
+         && curl https://osf.io/razk2/download \
+         && curl https://osf.io/qx29y/download \
+         && cat DICOM_dwifslpreproc-*.tar | tar -xi \
+         && rm -f DICOM_dwifslpreproc-*.tar" \
+   --env DEPLOY_PATH=${deployPath} \
+   --copy README.md /README.md \
+   --user=neuro \
+  > ${imageName}.${neurodocker_buildExt}
+
+# TODO Construct OverlayFS at /data to mount /opt/${toolName}-${toolVersion}/ as read-only
+
+if [ "$1" != "" ]; then
+   ./../main_build.sh
+fi

--- a/recipes/mrtrix3workshop/test.sh
+++ b/recipes/mrtrix3workshop/test.sh
@@ -1,0 +1,5 @@
+dwifslpreproc
+# shouldn't through any errors (e.g. distutils, no python available ...)
+
+mrview
+# should open up ok -> needs QT and doesn't come from neurodocker -> we tried a pull request, but it didn't get merged.


### PR DESCRIPTION
Erroneously initially posted as https://github.com/NeuroDesk/neurocontainers/pull/812.

- [ ] Address current build failure (following [docs](https://www.neurodesk.org/developers/new_tools/manual_build/):
    
    ```ShellSession
    $ ./build.sh -ds
    ...
    List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
    ```

    (Occurs even with `sudo`)

- [ ] Set up OverlayFS

    Downloaded exemplar workshop data should be flagged as read-only; there should then be a read-write mount broadcast to container users, which would allow copy & pasting of commands to regenerate files without necessitating use of the `-force` option, and would permit users to delete any data they have regenerated but protect against deletion of original downloaded data.

- [ ] Start expanding set of workshop material that is publicly visible

- [ ] Evaluate fitness for purpose:
    Cold vs. warm start
    Terminal command invocation lag
    Computational performance
    GUI startup lag
    GUI render performance
    Container size
